### PR TITLE
fix: support for non-ascii characters in file names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { config } from "./config";
 import { store, WikiPage } from "./store";
 
 export function sanitizeName(name: string) {
-  return name.replace(/\s/g, "-").replace(/[^\w\d-_]/g, "");
+  return name.replace(/\s/g, "-").replace(/[^\p{Letter}\d_-]/gu, "");
 }
 
 export const LINK_SELECTOR: DocumentSelector = [


### PR DESCRIPTION
Hi, thank you for the nice extension!

Since I'm Japanese I want to use it with non-ASCII characters.
Now, the command `Add Page` with a title written in Japanese (for example, `テスト`) creates not `テスト.md` but `.md`.

This PR adds support for any letter in file names.